### PR TITLE
[OpenXR-Loader] Add support for loading libraries from zip files

### DIFF
--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -60,6 +60,8 @@ bool FileSysUtilsIsDirectory(const std::string& path) { return FS_PREFIX::is_dir
 
 bool FileSysUtilsPathExists(const std::string& path) { return FS_PREFIX::exists(path); }
 
+bool FileSysUtilsLinkerPathExists(const std::string& path) { return FileSysUtilsPathExists(path); }
+
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
     FS_PREFIX::path file_path(path);
     return file_path.is_absolute();
@@ -138,6 +140,8 @@ bool FileSysUtilsIsDirectory(const std::string& path) {
 bool FileSysUtilsPathExists(const std::string& path) {
     return (GetFileAttributesW(utf8_to_wide(path).c_str()) != INVALID_FILE_ATTRIBUTES);
 }
+
+bool FileSysUtilsLinkerPathExists(const std::string& path) { return FileSysUtilsPathExists(path); }
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
     bool pathStartsWithDir = (path.size() >= 1) && ((path[0] == DIRECTORY_SYMBOL) || (path[0] == ALTERNATE_DIRECTORY_SYMBOL));
@@ -244,6 +248,20 @@ bool FileSysUtilsIsDirectory(const std::string& path) {
 }
 
 bool FileSysUtilsPathExists(const std::string& path) { return (access(path.c_str(), F_OK) != -1); }
+
+bool FileSysUtilsLinkerPathExists(const std::string& path) {
+  #ifdef XR_USE_PLATFORM_ANDROID
+  // Android's linker supports linking to libraries in zip files in the format of
+  // /path/to/zip!/path/to/lib
+  size_t pos = path.find("!/");
+  if (pos != std::string::npos) {
+    std::string apkPath = path.substr(0, pos);
+    // Assume the entry exists
+    return FileSysUtilsPathExists(apkPath);
+  }
+  #endif
+  return FileSysUtilsPathExists(path);
+}
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) { return (path[0] == DIRECTORY_SYMBOL); }
 

--- a/src/common/filesystem_utils.hpp
+++ b/src/common/filesystem_utils.hpp
@@ -21,6 +21,9 @@ bool FileSysUtilsIsDirectory(const std::string& path);
 // Determine if the provided path exists on the filesystem
 bool FileSysUtilsPathExists(const std::string& path);
 
+// Determine if the provided path exists to the linker
+bool FileSysUtilsLinkerPathExists(const std::string& path);
+
 // Get the current directory
 bool FileSysUtilsGetCurrentPath(std::string& path);
 


### PR DESCRIPTION
The linker from bionic on Android supports loading libraries from zip files. This is done by using a path of the format of /path/to/zip!/path/to/lib Currently if such a path is attempted to be loaded it will fail when it tries to check if that path exists not knowing that this is in a special format. Currently when faced with such a path it thinks that the library does not exit and will abort trying to use it.

This change adds limited support for library paths of this format. It currently only checks for the existence of the zip file and assumes that the library within exists. This avoids the complexity of trying to list the entries of the zip file.

This functionality is needed to support the library path found on v62 which is /system/priv-app/VrDriver/VrDriver.apk!/lib/arm64-v8a/libopenxr_forwardloader.so